### PR TITLE
Feature/support multiple ingresses

### DIFF
--- a/charts/app/templates/ingress.yaml
+++ b/charts/app/templates/ingress.yaml
@@ -1,44 +1,47 @@
-{{- if .Values.ingress.enabled -}}
-{{- $fullName := include "nmp-chart.deploymentName" . -}}
-{{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+{{- $fullName := include "nmp-chart.deploymentName" $ -}}
+{{- $svcPort := $.Values.service.port -}}
+{{- range .Values.ingress.ingresses -}}
+{{- $ingressClassName := coalesce .className $.Values.ingress.className -}}
+{{- $dnsSuffix := coalesce .dnsSuffix $.Values.ingress.dnsSuffix -}}
+{{- if and $ingressClassName (not (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .annotations "kubernetes.io/ingress.class" $ingressClassName}}
   {{- end }}
 {{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+---
+{{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare ">=1.14-0" $.Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ printf "%s-%s" $fullName .name }}
   labels:
-    {{- include "nmp-chart.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+    {{- include "nmp-chart.labels" $ | nindent 4 }}
+  {{- with ( merge (.annotations | default dict) $.Values.ingress.annotations ) }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
+  {{- if and $ingressClassName (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ $ingressClassName }}
   {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- if .tls }}
   tls:
-    {{- range .Values.ingress.tls }}
+    {{- range .tls }}
     - hosts:
         {{- range $host:=.hosts }}
-        - {{ $host }}.{{$.Values.ingress.tenantName}}.{{$.Values.ingress.dnsSuffix}}
+        - {{ $host }}.{{$.Values.ingress.tenantName}}.{{$dnsSuffix}}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host }}.{{$.Values.ingress.tenantName}}.{{$.Values.ingress.dnsSuffix}}
+    {{- range .hosts }}
+    - host: {{ .host }}.{{$.Values.ingress.tenantName}}.{{$dnsSuffix}}
       http:
         paths:
           {{- range .paths }}

--- a/charts/app/templates/ingress.yaml
+++ b/charts/app/templates/ingress.yaml
@@ -18,7 +18,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: {{ printf "%s-%s" $fullName .name }}
+  name: {{ $fullName }}-{{ .name }}
   labels:
     {{- include "nmp-chart.labels" $ | nindent 4 }}
   {{- with ( merge (.annotations | default dict) $.Values.ingress.annotations ) }}


### PR DESCRIPTION
Makes it possible to define multiple ingress resources for a given deployment. 

Multiple ingress resources can be defined in values.yaml as follows
```yaml
app:
  ingress:
     className: nginx-internal
     tenantName: saga-nmp
     dnsSuffix: np-nuuazure.dk
     annotations: 
       cert-manager.io/issuer: letsencrypt
     ingresses:
      - name: internal-ingress
        hosts:
          - host: service-name-env
            paths:
              - path: ...
                pathType:
        tls:
           - secretName: ...
             hosts:
               - ...
      - name: api-ingress
        className: nginx
        annotations:
          nginx.ingress.kubernetes.io/auth-url: ...
        hosts:
          - host: api
            paths:
              - path: ...
                pathType: ...
        tls:
           - secretName: ...
             hosts:
               - ...

```

The above yaml will produce the following ingress resource defintions:
```yaml
# Source: service-name/charts/app/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: service-name-internal-ingress
  labels:
    helm.sh/chart: app-2.2.1
    app.kubernetes.io/name: service-name
    app.kubernetes.io/instance: service-name
    aadpodidbinding: service-name
    app.kubernetes.io/managed-by: Helm
  annotations:
    cert-manager.io/issuer: letsencrypt
spec:
  ingressClassName: nginx-internal
  tls:
    - hosts:
        - service-name-env.saga-nmp.np-nuuazure.dk
      secretName: aks-nuuday-nmp-service-name-tls
  rules:
    - host: service-name-env.saga-nmp.np-nuuazure.dk
      http:
        paths:
          - path: ...
            pathType: ...
            backend:
              service:
                name: service-name
                port:
                  number: ...
---
# Source: service-name/charts/app/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: saga-service-name-api-ingress
  labels:
    helm.sh/chart: app-2.2.1
    app.kubernetes.io/name: service-name
    app.kubernetes.io/instance: service-name
    app.kubernetes.io/managed-by: Helm
  annotations:
    cert-manager.io/issuer: letsencrypt
    nginx.ingress.kubernetes.io/auth-url: ...
spec:
  ingressClassName: nginx
  tls:
    - hosts:
        - ...
          secretName: aks-nuuday-nmp-api-tls
  rules:
    - host: api.saga-nmp.np-nuuazure.dk
      http:
        paths:
          - path: /
            pathType: ImplementationSpecific
            backend:
              service:
                name: service-name
                port:
                  number: ...
```